### PR TITLE
Add central module to integrate ControllableYoutubePlayer and AnalogClock

### DIFF
--- a/src/app/clock/page.tsx
+++ b/src/app/clock/page.tsx
@@ -1,15 +1,17 @@
 'use client';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import AnalogClock from '@/modules/AnalogClock/AnalogClock';
-import { generateTestIntervals } from '@/modules/AnalogClock/_tests_/getIntervals';
-
-const intervals = generateTestIntervals();
 
 const Home: React.FC = () => {
-  const handleIntervalChange = (nextInterval: any) => {
-    console.log('Interval changed:', nextInterval);
-    // Here you can add logic to handle interval changes
-  };
+  const [intervals, setIntervals] = useState<Interval[]>([]);
+
+  useEffect(() => {
+    const savedState = localStorage.getItem('centralModuleState');
+    if (savedState) {
+      const parsedState = JSON.parse(savedState);
+      setIntervals(parsedState.intervals);
+    }
+  }, []);
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center p-4">
@@ -17,10 +19,7 @@ const Home: React.FC = () => {
         Детское расписание
       </h1>
       <div className="bg-white rounded-lg shadow-xl p-6 w-[800px] h-[600px]">
-        <AnalogClock
-          intervals={intervals}
-          // onIntervalChange={handleIntervalChange}
-        />
+        <AnalogClock intervals={intervals} />
       </div>
       <div className="mt-8 bg-white rounded-lg shadow-lg p-6">
         <h2 className="text-xl font-semibold mb-4 text-gray-800">Легенда:</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import CentralModule from '@/modules/CentralModule/CentralModule';
+import CentralModule from '@/modules/CentralModule/CentralModule2';
 
 export default function Home() {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
-import { VIDEO_CONFIG } from '@/config';
+import CentralModule from '@/modules/CentralModule/CentralModule';
 
 export default function Home() {
   return (
     <main>
       <h1>Youtube player with Parent control</h1>
-      <ControllableYoutubePlayer
-        videoId="wVH6vZiWrl8"
-        timeLimit={VIDEO_CONFIG.DEFAULT_VIDEO_LENGTH}
-      />
+      <CentralModule />
     </main>
   );
 }

--- a/src/modules/AnalogClock/AnalogClock.tsx
+++ b/src/modules/AnalogClock/AnalogClock.tsx
@@ -1,16 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import ClockUI from './ClockUI';
+import { Interval } from '../types';
 
-type IntervalStatus = 'passed' | 'current' | 'upcoming';
 
-type Interval = {
-  startTime: string;
-  endTime: string;
-  icon: React.ReactElement;
-  color: string;
-  label: string;
-  status?: IntervalStatus;
-};
 
 type Options = {
   showIcons: boolean;
@@ -45,37 +37,30 @@ const AnalogClock: React.FC<AnalogClockProps> = ({
 
   useEffect(() => {
     const filterIntervals = (currentTime: Date) => {
-      const currentMinutes =
-        currentTime.getHours() * 60 + currentTime.getMinutes();
       const fiveMinutesAgo = new Date(currentTime.getTime() - 5 * 60000);
       const fortyFiveMinutesLater = new Date(
         currentTime.getTime() + 45 * 60000,
       );
 
       return intervals.reduce((acc: Interval[], interval: Interval) => {
-        const start = new Date(`1970-01-01T${interval.startTime}:00`);
-        const end = new Date(`1970-01-01T${interval.endTime}:00`);
-        const startMinutes = start.getHours() * 60 + start.getMinutes();
-        const endMinutes = end.getHours() * 60 + end.getMinutes();
-
-        if (startMinutes > currentMinutes + 45) return acc;
+        if (interval.startTime.getTime() > currentTime.getTime() + 45 * 60000)
+          return acc;
 
         let newInterval = { ...interval };
 
-        if (startMinutes < currentMinutes - 5) {
-          if (endMinutes <= currentMinutes - 5) return acc;
-          newInterval.startTime = fiveMinutesAgo.toTimeString().slice(0, 5);
+        if (interval.startTime.getTime() < currentTime.getTime() - 5 * 60000) {
+          if (interval.endTime.getTime() <= currentTime.getTime() - 5 * 60000)
+            return acc;
+          newInterval.startTime = fiveMinutesAgo;
         }
 
-        if (endMinutes > currentMinutes + 45) {
-          newInterval.endTime = fortyFiveMinutesLater
-            .toTimeString()
-            .slice(0, 5);
+        if (interval.endTime.getTime() > currentTime.getTime() + 45 * 60000) {
+          newInterval.endTime = fortyFiveMinutesLater;
         }
 
-        if (endMinutes <= currentMinutes) {
+        if (interval.endTime.getTime() <= currentTime.getTime()) {
           newInterval.status = 'passed';
-        } else if (startMinutes > currentMinutes) {
+        } else if (interval.startTime.getTime() > currentTime.getTime()) {
           newInterval.status = 'upcoming';
         } else {
           newInterval.status = 'current';
@@ -88,15 +73,11 @@ const AnalogClock: React.FC<AnalogClockProps> = ({
     setFilteredIntervals(filterIntervals(time));
   }, [time, intervals]);
 
-  const hours = time.getHours();
-  const minutes = time.getMinutes();
-  const seconds = time.getSeconds();
-
   return (
     <ClockUI
-      hours={hours}
-      minutes={minutes}
-      seconds={seconds}
+      hours={time.getHours()}
+      minutes={time.getMinutes()}
+      seconds={time.getSeconds()}
       intervals={filteredIntervals}
       showIcons={showIcons}
     />

--- a/src/modules/AnalogClock/AnalogClock.tsx
+++ b/src/modules/AnalogClock/AnalogClock.tsx
@@ -12,11 +12,24 @@ type Interval = {
   status?: IntervalStatus;
 };
 
-type AnalogClockProps = {
-  intervals: Interval[];
+type Options = {
+  showIcons: boolean;
 };
 
-const AnalogClock: React.FC<AnalogClockProps> = ({ intervals }) => {
+type AnalogClockProps = {
+  intervals: Interval[];
+  options: Options;
+};
+
+const defaultOptions: Options = {
+  showIcons: true,
+};
+
+const AnalogClock: React.FC<AnalogClockProps> = ({
+  intervals,
+  options = defaultOptions,
+}) => {
+  const { showIcons = defaultOptions.showIcons } = options;
   const [time, setTime] = useState<Date>(new Date());
   const [filteredIntervals, setFilteredIntervals] = useState<Interval[]>([]);
 
@@ -85,6 +98,7 @@ const AnalogClock: React.FC<AnalogClockProps> = ({ intervals }) => {
       minutes={minutes}
       seconds={seconds}
       intervals={filteredIntervals}
+      showIcons={showIcons}
     />
   );
 };

--- a/src/modules/AnalogClock/ClockUI.tsx
+++ b/src/modules/AnalogClock/ClockUI.tsx
@@ -1,15 +1,5 @@
 import React from 'react';
-
-type IntervalStatus = 'passed' | 'current' | 'upcoming';
-
-type Interval = {
-  startTime: string;
-  endTime: string;
-  icon: React.ReactElement;
-  color: string;
-  label: string;
-  status: IntervalStatus;
-};
+import { Interval } from '../types';
 
 type ClockUIProps = {
   hours: number;
@@ -224,9 +214,10 @@ const ClockUI: React.FC<ClockUIProps> = ({
   };
 
   const createIntervalSector = (interval: Interval) => {
-    const timeToAngle = (time: string) => {
-      const [, m] = time.split(':').map(Number);
-      return m * 6;
+    const timeToAngle = (time: Date): number => {
+      const minutes = time.getMinutes();
+      const seconds = time.getSeconds();
+      return (minutes * 60 + seconds) * 0.1;
     };
 
     const startAngle = timeToAngle(interval.startTime);
@@ -261,7 +252,7 @@ const ClockUI: React.FC<ClockUIProps> = ({
     const iconX = center + iconRadius * Math.sin((iconAngle * Math.PI) / 180);
     const iconY = center - iconRadius * Math.cos((iconAngle * Math.PI) / 180);
 
-    const opacity = clockTheme.opacity[interval.status];
+    const opacity = clockTheme.opacity[interval.status!];
 
     return (
       <g key={interval.startTime} xlinkTitle={interval.label}>

--- a/src/modules/AnalogClock/ClockUI.tsx
+++ b/src/modules/AnalogClock/ClockUI.tsx
@@ -17,6 +17,7 @@ type ClockUIProps = {
   seconds: number;
   intervals: Interval[];
   theme?: 'light' | 'dark';
+  showIcons: boolean;
 };
 
 const clockThemeLight = {
@@ -57,8 +58,8 @@ const clockThemeDark = {
 
 const themes = {
   light: clockThemeLight,
-  dark: clockThemeDark
-}
+  dark: clockThemeDark,
+};
 
 const ClockUI: React.FC<ClockUIProps> = ({
   hours,
@@ -66,6 +67,7 @@ const ClockUI: React.FC<ClockUIProps> = ({
   seconds,
   intervals,
   theme = 'light',
+  showIcons,
 }) => {
   const clockTheme = themes[theme];
   const radius = 100;
@@ -262,23 +264,32 @@ const ClockUI: React.FC<ClockUIProps> = ({
     const opacity = clockTheme.opacity[interval.status];
 
     return (
-      <g key={interval.startTime}>
+      <g key={interval.startTime} xlinkTitle={interval.label}>
         <path d={path} fill={interval.color} opacity={opacity} />
-        <circle
-          cx={iconX}
-          cy={iconY}
-          r={radius * 0.07}
-          fill={interval.color}
-          stroke={interval.color}
-          strokeWidth="1"
-          opacity="1"
-        />
-        <foreignObject x={iconX - 4} y={iconY - 4} width="12" height="12">
-          {React.cloneElement(interval.icon, {
-            className: `${interval.icon.props.className} absolute`,
-            style: { color: 'white', width: '60%', height: '60%', opacity: 1 },
-          })}
-        </foreignObject>
+        {showIcons ? (
+          <>
+            <circle
+              cx={iconX}
+              cy={iconY}
+              r={radius * 0.07}
+              fill={interval.color}
+              stroke={interval.color}
+              strokeWidth="1"
+              opacity="1"
+            />
+            <foreignObject x={iconX - 4} y={iconY - 4} width="12" height="12">
+              {React.cloneElement(interval.icon, {
+                className: `${interval.icon.props.className} absolute`,
+                style: {
+                  color: 'white',
+                  width: '60%',
+                  height: '60%',
+                  opacity: 1,
+                },
+              })}
+            </foreignObject>
+          </>
+        ) : null}
       </g>
     );
   };

--- a/src/modules/CentralModule/CentralModule.tsx
+++ b/src/modules/CentralModule/CentralModule.tsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
+import AnalogClock from '@/modules/AnalogClock/AnalogClock';
+
+type Interval = {
+  startTime: string;
+  endTime: string;
+  icon: React.ReactElement;
+  color: string;
+  label: string;
+};
+
+const WATCH_TIME = 15 * 60; // 15 minutes in seconds
+const BREAK_TIME = 10 * 60; // 10 minutes in seconds
+
+const CentralModule: React.FC = () => {
+  const [intervals, setIntervals] = useState<Interval[]>([]);
+  const [watchTimeRemaining, setWatchTimeRemaining] = useState(WATCH_TIME);
+  const [breakTimeRemaining, setBreakTimeRemaining] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isBreak, setIsBreak] = useState(false);
+
+  useEffect(() => {
+    const savedState = localStorage.getItem('centralModuleState');
+    if (savedState) {
+      const parsedState = JSON.parse(savedState);
+      setIntervals(parsedState.intervals);
+      setWatchTimeRemaining(parsedState.watchTimeRemaining);
+      setBreakTimeRemaining(parsedState.breakTimeRemaining);
+      setIsPlaying(parsedState.isPlaying);
+      setIsBreak(parsedState.isBreak);
+    } else {
+      initializeIntervals();
+    }
+  }, []);
+
+  useEffect(() => {
+    const state = {
+      intervals,
+      watchTimeRemaining,
+      breakTimeRemaining,
+      isPlaying,
+      isBreak,
+    };
+    localStorage.setItem('centralModuleState', JSON.stringify(state));
+  }, [intervals, watchTimeRemaining, breakTimeRemaining, isPlaying, isBreak]);
+
+  const initializeIntervals = () => {
+    const now = new Date();
+    const newIntervals: Interval[] = [
+      {
+        startTime: formatTime(now),
+        endTime: formatTime(addSeconds(now, WATCH_TIME)),
+        icon: <span>🎥</span>,
+        color: '#059669',
+        label: 'Watch Time',
+      },
+      {
+        startTime: formatTime(addSeconds(now, WATCH_TIME)),
+        endTime: formatTime(addSeconds(now, WATCH_TIME + BREAK_TIME)),
+        icon: <span>⏸️</span>,
+        color: '#DC2626',
+        label: 'Break Time',
+      },
+    ];
+    setIntervals(newIntervals);
+  };
+
+  const formatTime = (date: Date): string => {
+    return date.toTimeString().slice(0, 5);
+  };
+
+  const addSeconds = (date: Date, seconds: number): Date => {
+    return new Date(date.getTime() + seconds * 1000);
+  };
+
+  const handlePlayPause = () => {
+    if (isBreak) return;
+    setIsPlaying((prev) => !prev);
+  };
+
+  const handleTimeUpdate = () => {
+    if (isPlaying) {
+      setWatchTimeRemaining((prev) => {
+        if (prev <= 1) {
+          setIsPlaying(false);
+          setIsBreak(true);
+          setBreakTimeRemaining(BREAK_TIME);
+          return WATCH_TIME;
+        }
+        return prev - 1;
+      });
+    } else if (isBreak) {
+      setBreakTimeRemaining((prev) => {
+        if (prev <= 1) {
+          setIsBreak(false);
+          setWatchTimeRemaining(WATCH_TIME);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }
+  };
+
+  useEffect(() => {
+    const timer = setInterval(handleTimeUpdate, 1000);
+    return () => clearInterval(timer);
+  }, [isPlaying, isBreak]);
+
+  return (
+    <div>
+      <ControllableYoutubePlayer
+        videoId="wVH6vZiWrl8"
+        timeLimit={watchTimeRemaining}
+      />
+      <AnalogClock intervals={intervals} />
+      <button onClick={handlePlayPause}>
+        {isPlaying ? 'Pause' : 'Play'}
+      </button>
+    </div>
+  );
+};
+
+export default CentralModule;

--- a/src/modules/CentralModule/CentralModule.tsx
+++ b/src/modules/CentralModule/CentralModule.tsx
@@ -1,26 +1,21 @@
 import React, { useState, useEffect } from 'react';
 import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
 import AnalogClock from '@/modules/AnalogClock/AnalogClock';
+import { Interval } from './types';
 
-type Interval = {
-  startTime: string;
-  endTime: string;
-  icon: React.ReactElement;
-  color: string;
-  label: string;
-};
 
-const WATCH_TIME = 2 * 60; // 15 minutes in seconds
+
+const WATCH_TIME = 8 * 60; // 15 minutes in seconds
 const BREAK_TIME = 2 * 60; // 10 minutes in seconds
 
 const CentralModule: React.FC = () => {
   const [intervals, setIntervals] = useState<Interval[]>([]);
   const [periodStartTime, setPeriodStartTime] = useState<Date>(new Date());
   const [currentPeriodEndTime, setCurrentPeriodEndTime] = useState<Date>(
-    new Date()
+    new Date(),
   );
   const [currentPeriodType, setCurrentPeriodType] = useState<'watch' | 'break'>(
-    'watch'
+    'watch',
   );
   const [isPlaying, setIsPlaying] = useState(false);
   const [totalPauseTimeDuringWatchPeriod, setTotalPauseTimeDuringWatchPeriod] =
@@ -38,10 +33,10 @@ const CentralModule: React.FC = () => {
       setCurrentPeriodType(parsedState.currentPeriodType);
       setIsPlaying(parsedState.isPlaying);
       setTotalPauseTimeDuringWatchPeriod(
-        parsedState.totalPauseTimeDuringWatchPeriod
+        parsedState.totalPauseTimeDuringWatchPeriod,
       );
       setLastPauseTime(
-        parsedState.lastPauseTime ? new Date(parsedState.lastPauseTime) : null
+        parsedState.lastPauseTime ? new Date(parsedState.lastPauseTime) : null,
       );
       setTimeLimit(parsedState.timeLimit);
     } else {
@@ -93,7 +88,7 @@ const CentralModule: React.FC = () => {
       // Resuming play
       if (lastPauseTime) {
         const pauseDuration = Math.floor(
-          (now.getTime() - lastPauseTime.getTime()) / 1000
+          (now.getTime() - lastPauseTime.getTime()) / 1000,
         );
 
         if (currentPeriodType === 'watch') {
@@ -110,9 +105,7 @@ const CentralModule: React.FC = () => {
             return;
           } else {
             // Add to totalPauseTimeDuringWatchPeriod
-            setTotalPauseTimeDuringWatchPeriod(
-              (prev) => prev + pauseDuration
-            );
+            setTotalPauseTimeDuringWatchPeriod((prev) => prev + pauseDuration);
           }
         }
         setLastPauseTime(null);
@@ -130,7 +123,7 @@ const CentralModule: React.FC = () => {
 
     // Calculate remaining time
     const remainingTime = Math.floor(
-      (currentPeriodEndTime.getTime() - now.getTime()) / 1000
+      (currentPeriodEndTime.getTime() - now.getTime()) / 1000,
     );
     setTimeLimit(remainingTime > 0 ? remainingTime : 0);
 
@@ -143,7 +136,7 @@ const CentralModule: React.FC = () => {
         // Adjust break time
         const adjustedBreakTime = Math.max(
           0,
-          BREAK_TIME - totalPauseTimeDuringWatchPeriod
+          BREAK_TIME - totalPauseTimeDuringWatchPeriod,
         );
 
         setPeriodStartTime(now);
@@ -182,7 +175,7 @@ const CentralModule: React.FC = () => {
   const updateIntervals = (
     startTime: Date,
     periodType: 'watch' | 'break',
-    duration: number
+    duration: number,
   ) => {
     const intervals: Interval[] = [];
     let currentTime = startTime;
@@ -231,11 +224,13 @@ const CentralModule: React.FC = () => {
         videoId="wVH6vZiWrl8"
         onPlayPause={handlePlayPause}
         timeLimit={timeLimit}
-        isPlaying={isPlaying && currentPeriodType === 'watch'} // Prevent playing during break
+        isPlaying={isPlaying && currentPeriodType === 'watch'}
+        renderWidget={() => (
+          <div className="w-96">
+            <AnalogClock intervals={intervals} options={{ showIcons: false }} />
+          </div>
+        )}
       />
-      <div className="w-96">
-        <AnalogClock intervals={intervals} />
-      </div>
     </div>
   );
 };

--- a/src/modules/CentralModule/CentralModule.tsx
+++ b/src/modules/CentralModule/CentralModule.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
 import AnalogClock from '@/modules/AnalogClock/AnalogClock';
 
@@ -10,61 +10,73 @@ type Interval = {
   label: string;
 };
 
-const WATCH_TIME = 15 * 60; // 15 minutes in seconds
-const BREAK_TIME = 10 * 60; // 10 minutes in seconds
+const WATCH_TIME = 2 * 60; // 15 minutes in seconds
+const BREAK_TIME = 2 * 60; // 10 minutes in seconds
 
 const CentralModule: React.FC = () => {
   const [intervals, setIntervals] = useState<Interval[]>([]);
-  const [watchTimeRemaining, setWatchTimeRemaining] = useState(WATCH_TIME);
-  const [breakTimeRemaining, setBreakTimeRemaining] = useState(0);
+  const [periodStartTime, setPeriodStartTime] = useState<Date>(new Date());
+  const [currentPeriodEndTime, setCurrentPeriodEndTime] = useState<Date>(
+    new Date()
+  );
+  const [currentPeriodType, setCurrentPeriodType] = useState<'watch' | 'break'>(
+    'watch'
+  );
   const [isPlaying, setIsPlaying] = useState(false);
-  const [isBreak, setIsBreak] = useState(false);
+  const [totalPauseTimeDuringWatchPeriod, setTotalPauseTimeDuringWatchPeriod] =
+    useState(0);
+  const [lastPauseTime, setLastPauseTime] = useState<Date | null>(null);
+  const [timeLimit, setTimeLimit] = useState<number>(WATCH_TIME); // Time limit in seconds
 
   useEffect(() => {
     const savedState = localStorage.getItem('centralModuleState');
     if (savedState) {
       const parsedState = JSON.parse(savedState);
       setIntervals(parsedState.intervals);
-      setWatchTimeRemaining(parsedState.watchTimeRemaining);
-      setBreakTimeRemaining(parsedState.breakTimeRemaining);
+      setPeriodStartTime(new Date(parsedState.periodStartTime));
+      setCurrentPeriodEndTime(new Date(parsedState.currentPeriodEndTime));
+      setCurrentPeriodType(parsedState.currentPeriodType);
       setIsPlaying(parsedState.isPlaying);
-      setIsBreak(parsedState.isBreak);
+      setTotalPauseTimeDuringWatchPeriod(
+        parsedState.totalPauseTimeDuringWatchPeriod
+      );
+      setLastPauseTime(
+        parsedState.lastPauseTime ? new Date(parsedState.lastPauseTime) : null
+      );
+      setTimeLimit(parsedState.timeLimit);
     } else {
-      initializeIntervals();
+      // Initialize periods
+      const now = new Date();
+      setPeriodStartTime(now);
+      setCurrentPeriodEndTime(new Date(now.getTime() + WATCH_TIME * 1000));
+      setCurrentPeriodType('watch');
+      setTimeLimit(WATCH_TIME);
+      updateIntervals(now, 'watch', WATCH_TIME);
     }
   }, []);
 
   useEffect(() => {
     const state = {
       intervals,
-      watchTimeRemaining,
-      breakTimeRemaining,
+      periodStartTime: periodStartTime.toISOString(),
+      currentPeriodEndTime: currentPeriodEndTime.toISOString(),
+      currentPeriodType,
       isPlaying,
-      isBreak,
+      totalPauseTimeDuringWatchPeriod,
+      lastPauseTime: lastPauseTime ? lastPauseTime.toISOString() : null,
+      timeLimit,
     };
     localStorage.setItem('centralModuleState', JSON.stringify(state));
-  }, [intervals, watchTimeRemaining, breakTimeRemaining, isPlaying, isBreak]);
-
-  const initializeIntervals = () => {
-    const now = new Date();
-    const newIntervals: Interval[] = [
-      {
-        startTime: formatTime(now),
-        endTime: formatTime(addSeconds(now, WATCH_TIME)),
-        icon: <span>🎥</span>,
-        color: '#059669',
-        label: 'Watch Time',
-      },
-      {
-        startTime: formatTime(addSeconds(now, WATCH_TIME)),
-        endTime: formatTime(addSeconds(now, WATCH_TIME + BREAK_TIME)),
-        icon: <span>⏸️</span>,
-        color: '#DC2626',
-        label: 'Break Time',
-      },
-    ];
-    setIntervals(newIntervals);
-  };
+  }, [
+    intervals,
+    periodStartTime,
+    currentPeriodEndTime,
+    currentPeriodType,
+    isPlaying,
+    totalPauseTimeDuringWatchPeriod,
+    lastPauseTime,
+    timeLimit,
+  ]);
 
   const formatTime = (date: Date): string => {
     return date.toTimeString().slice(0, 5);
@@ -74,47 +86,156 @@ const CentralModule: React.FC = () => {
     return new Date(date.getTime() + seconds * 1000);
   };
 
-  const handlePlayPause = (isPlaying: boolean) => {
-    if (isBreak) return;
-    setIsPlaying(isPlaying);
+  const handlePlayPause = (playing: boolean) => {
+    const now = new Date();
+
+    if (playing) {
+      // Resuming play
+      if (lastPauseTime) {
+        const pauseDuration = Math.floor(
+          (now.getTime() - lastPauseTime.getTime()) / 1000
+        );
+
+        if (currentPeriodType === 'watch') {
+          if (pauseDuration >= BREAK_TIME) {
+            // Break time has been exceeded, start new watch period
+            setCurrentPeriodType('watch');
+            setPeriodStartTime(now);
+            setCurrentPeriodEndTime(addSeconds(now, WATCH_TIME));
+            setTotalPauseTimeDuringWatchPeriod(0);
+            setLastPauseTime(null);
+            setTimeLimit(WATCH_TIME);
+            updateIntervals(now, 'watch', WATCH_TIME);
+            setIsPlaying(true);
+            return;
+          } else {
+            // Add to totalPauseTimeDuringWatchPeriod
+            setTotalPauseTimeDuringWatchPeriod(
+              (prev) => prev + pauseDuration
+            );
+          }
+        }
+        setLastPauseTime(null);
+      }
+      setIsPlaying(true);
+    } else {
+      // Pausing play
+      setIsPlaying(false);
+      setLastPauseTime(now);
+    }
   };
 
   const handleTimeUpdate = () => {
-    if (isPlaying) {
-      setWatchTimeRemaining((prev) => {
-        if (prev <= 1) {
-          setIsPlaying(false);
-          setIsBreak(true);
-          setBreakTimeRemaining(BREAK_TIME);
-          return WATCH_TIME;
-        }
-        return prev - 1;
-      });
-    } else if (isBreak) {
-      setBreakTimeRemaining((prev) => {
-        if (prev <= 1) {
-          setIsBreak(false);
-          setWatchTimeRemaining(WATCH_TIME);
-          return 0;
-        }
-        return prev - 1;
-      });
+    const now = new Date();
+
+    // Calculate remaining time
+    const remainingTime = Math.floor(
+      (currentPeriodEndTime.getTime() - now.getTime()) / 1000
+    );
+    setTimeLimit(remainingTime > 0 ? remainingTime : 0);
+
+    if (currentPeriodType === 'watch') {
+      if (now >= currentPeriodEndTime) {
+        // Watch period over
+        setIsPlaying(false);
+        setCurrentPeriodType('break');
+
+        // Adjust break time
+        const adjustedBreakTime = Math.max(
+          0,
+          BREAK_TIME - totalPauseTimeDuringWatchPeriod
+        );
+
+        setPeriodStartTime(now);
+        setCurrentPeriodEndTime(addSeconds(now, adjustedBreakTime));
+
+        // Reset totalPauseTimeDuringWatchPeriod
+        setTotalPauseTimeDuringWatchPeriod(0);
+
+        // Update intervals
+        updateIntervals(now, 'break', adjustedBreakTime);
+
+        // Update timeLimit
+        setTimeLimit(adjustedBreakTime);
+      }
+    } else if (currentPeriodType === 'break') {
+      if (now >= currentPeriodEndTime) {
+        // Break period over
+        setCurrentPeriodType('watch');
+        setPeriodStartTime(now);
+        setCurrentPeriodEndTime(addSeconds(now, WATCH_TIME));
+
+        // Update intervals
+        updateIntervals(now, 'watch', WATCH_TIME);
+
+        // Update timeLimit
+        setTimeLimit(WATCH_TIME);
+      }
     }
   };
 
   useEffect(() => {
     const timer = setInterval(handleTimeUpdate, 1000);
     return () => clearInterval(timer);
-  }, [isPlaying, isBreak]);
+  });
+
+  const updateIntervals = (
+    startTime: Date,
+    periodType: 'watch' | 'break',
+    duration: number
+  ) => {
+    const intervals: Interval[] = [];
+    let currentTime = startTime;
+    let type = periodType;
+    let totalPauseTime = totalPauseTimeDuringWatchPeriod;
+    let periodEndTime = addSeconds(currentTime, duration);
+
+    // Current interval
+    intervals.push({
+      startTime: formatTime(currentTime),
+      endTime: formatTime(periodEndTime),
+      icon: type === 'watch' ? <span>🎥</span> : <span>⏸️</span>,
+      color: type === 'watch' ? '#059669' : '#DC2626',
+      label: type === 'watch' ? 'Watch Time' : 'Break Time',
+    });
+
+    // Next two intervals
+    for (let i = 0; i < 2; i++) {
+      currentTime = periodEndTime;
+      if (type === 'watch') {
+        // Next is Break Time
+        const adjustedBreakTime = Math.max(0, BREAK_TIME - totalPauseTime);
+        periodEndTime = addSeconds(currentTime, adjustedBreakTime);
+        type = 'break';
+      } else {
+        // Next is Watch Time
+        periodEndTime = addSeconds(currentTime, WATCH_TIME);
+        type = 'watch';
+        totalPauseTime = 0; // Reset totalPauseTime when new watch period starts
+      }
+      intervals.push({
+        startTime: formatTime(currentTime),
+        endTime: formatTime(periodEndTime),
+        icon: type === 'watch' ? <span>🎥</span> : <span>⏸️</span>,
+        color: type === 'watch' ? '#059669' : '#DC2626',
+        label: type === 'watch' ? 'Watch Time' : 'Break Time',
+      });
+    }
+
+    setIntervals(intervals);
+  };
 
   return (
     <div>
       <ControllableYoutubePlayer
         videoId="wVH6vZiWrl8"
-        timeLimit={watchTimeRemaining}
         onPlayPause={handlePlayPause}
+        timeLimit={timeLimit}
+        isPlaying={isPlaying && currentPeriodType === 'watch'} // Prevent playing during break
       />
-      <AnalogClock intervals={intervals} />
+      <div className="w-96">
+        <AnalogClock intervals={intervals} />
+      </div>
     </div>
   );
 };

--- a/src/modules/CentralModule/CentralModule.tsx
+++ b/src/modules/CentralModule/CentralModule.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
 import AnalogClock from '@/modules/AnalogClock/AnalogClock';
-import { Interval } from './types';
+import { Interval } from '../types';
 
 
 

--- a/src/modules/CentralModule/CentralModule.tsx
+++ b/src/modules/CentralModule/CentralModule.tsx
@@ -74,9 +74,9 @@ const CentralModule: React.FC = () => {
     return new Date(date.getTime() + seconds * 1000);
   };
 
-  const handlePlayPause = () => {
+  const handlePlayPause = (isPlaying: boolean) => {
     if (isBreak) return;
-    setIsPlaying((prev) => !prev);
+    setIsPlaying(isPlaying);
   };
 
   const handleTimeUpdate = () => {
@@ -112,11 +112,9 @@ const CentralModule: React.FC = () => {
       <ControllableYoutubePlayer
         videoId="wVH6vZiWrl8"
         timeLimit={watchTimeRemaining}
+        onPlayPause={handlePlayPause}
       />
       <AnalogClock intervals={intervals} />
-      <button onClick={handlePlayPause}>
-        {isPlaying ? 'Pause' : 'Play'}
-      </button>
     </div>
   );
 };

--- a/src/modules/CentralModule/CentralModule2.tsx
+++ b/src/modules/CentralModule/CentralModule2.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
 import AnalogClock from '@/modules/AnalogClock/AnalogClock';
-import { Interval } from './types';
 import { buildInitialIntervals } from './model';
+import { Interval } from '../types';
 
-const WATCH_TIME = 1 * 60; // 15 minutes in seconds
+const WATCH_TIME = 0.5 * 60; // 15 minutes in seconds
 const BREAK_TIME = 0.5 * 60; // 10 minutes in seconds
 
 const CentralModule: React.FC = () => {
@@ -32,18 +32,23 @@ const CentralModule: React.FC = () => {
   }, []);
 
   const handleReachedTimeLimit = () => {
-    // setTimeLimit(0);
+    setTimeLimit(0);
+    setPlayingMode('break');
     // // TODO: add a ref to setTimeout and disable it on component unmount
-    // setTimeout(() => {}, BREAK_TIME * 1000);
+    setTimeout(() => {
+      setIntervals(buildInitialIntervals(new Date(), WATCH_TIME, BREAK_TIME));
+      setTimeLimit(WATCH_TIME);
+      setPlayingMode('paused');
+    }, BREAK_TIME * 1000);
   };
 
   return (
     <div>
       <ControllableYoutubePlayer
         videoId="wVH6vZiWrl8"
-        // onPlayPause={handlePlayPause}
-        timeLimit={WATCH_TIME}
-        // onTimeLimit={handleReachedTimeLimit}
+        onPlayPause={handlePlayPause}
+        timeLimit={timeLimit}
+        onTimeLimit={handleReachedTimeLimit}
         renderWidget={() => (
           <div className="w-96">
             <AnalogClock intervals={intervals} options={{ showIcons: false }} />

--- a/src/modules/CentralModule/CentralModule2.tsx
+++ b/src/modules/CentralModule/CentralModule2.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import ControllableYoutubePlayer from '@/modules/ControllableYoutubePlayer/ControllableYoutubePlayer';
+import AnalogClock from '@/modules/AnalogClock/AnalogClock';
+import { Interval } from './types';
+import { buildInitialIntervals } from './model';
+
+const WATCH_TIME = 1 * 60; // 15 minutes in seconds
+const BREAK_TIME = 0.5 * 60; // 10 minutes in seconds
+
+const CentralModule: React.FC = () => {
+  const [intervals, setIntervals] = useState<Interval[]>([]);
+  const [playingMode, setPlayingMode] = useState<
+    'watching' | 'paused' | 'break'
+  >('paused');
+  const [timeLimit, setTimeLimit] = useState<number>(WATCH_TIME);
+
+  const handlePlayPause = (isPlaying: boolean) => {
+    if (playingMode === 'break') {
+      // not allowed to watch
+      return;
+    }
+    if (isPlaying) {
+      setPlayingMode('watching');
+    } else {
+      // allowed to watch but user sets on pause
+      setPlayingMode('paused');
+    }
+  };
+
+  useEffect(() => {
+    setIntervals(buildInitialIntervals(new Date(), WATCH_TIME, BREAK_TIME));
+  }, []);
+
+  const handleReachedTimeLimit = () => {
+    // setTimeLimit(0);
+    // // TODO: add a ref to setTimeout and disable it on component unmount
+    // setTimeout(() => {}, BREAK_TIME * 1000);
+  };
+
+  return (
+    <div>
+      <ControllableYoutubePlayer
+        videoId="wVH6vZiWrl8"
+        // onPlayPause={handlePlayPause}
+        timeLimit={WATCH_TIME}
+        // onTimeLimit={handleReachedTimeLimit}
+        renderWidget={() => (
+          <div className="w-96">
+            <AnalogClock intervals={intervals} options={{ showIcons: false }} />
+          </div>
+        )}
+      />
+    </div>
+  );
+};
+
+export default CentralModule;

--- a/src/modules/CentralModule/model.ts
+++ b/src/modules/CentralModule/model.ts
@@ -1,4 +1,4 @@
-import { Interval } from './types';
+import { Interval } from "../types";
 
 const formatTime = (date: Date): string => {
   return date.toTimeString().slice(0, 5);
@@ -14,8 +14,8 @@ const createInterval = (
   type: 'watch' | 'break',
 ): Interval => {
   return {
-    startTime: formatTime(startTime),
-    endTime: formatTime(endTime),
+    startTime,
+    endTime,
     icon: type === 'watch' ? '🎥' : '⏸️',
     color: type === 'watch' ? '#059669' : '#DC2626',
     label: type === 'watch' ? 'Watch Time' : 'Break Time',

--- a/src/modules/CentralModule/model.ts
+++ b/src/modules/CentralModule/model.ts
@@ -1,0 +1,46 @@
+import { Interval } from './types';
+
+const formatTime = (date: Date): string => {
+  return date.toTimeString().slice(0, 5);
+};
+
+const addSeconds = (date: Date, seconds: number): Date => {
+  return new Date(date.getTime() + seconds * 1000);
+};
+
+const createInterval = (
+  startTime: Date,
+  endTime: Date,
+  type: 'watch' | 'break',
+): Interval => {
+  return {
+    startTime: formatTime(startTime),
+    endTime: formatTime(endTime),
+    icon: type === 'watch' ? '🎥' : '⏸️',
+    color: type === 'watch' ? '#059669' : '#DC2626',
+    label: type === 'watch' ? 'Watch Time' : 'Break Time',
+  };
+};
+
+export const buildInitialIntervals = (
+  startTime: Date,
+  watchTime: number,
+  breakTime: number,
+): Interval[] => {
+  const periods = Math.ceil(45 * 60 / (watchTime + breakTime));
+  const intervals: Interval[] = [];
+
+  let watchStartTime = startTime;
+  new Array(periods).fill(1).forEach(() => {
+    const watchEndTime = addSeconds(watchStartTime, watchTime);
+    const breakEndTime = addSeconds(watchEndTime, breakTime);
+    intervals.push(createInterval(watchStartTime, watchEndTime, 'watch'));
+    intervals.push(createInterval(watchEndTime, breakEndTime, 'break'));
+    watchStartTime = breakEndTime;
+  });
+
+  return intervals;
+};
+
+
+

--- a/src/modules/CentralModule/types.ts
+++ b/src/modules/CentralModule/types.ts
@@ -1,0 +1,7 @@
+export type Interval = {
+  startTime: string;
+  endTime: string;
+  icon: React.ReactElement | string;
+  color: string;
+  label: string;
+};

--- a/src/modules/CentralModule/types.ts
+++ b/src/modules/CentralModule/types.ts
@@ -1,7 +1,0 @@
-export type Interval = {
-  startTime: string;
-  endTime: string;
-  icon: React.ReactElement | string;
-  color: string;
-  label: string;
-};

--- a/src/modules/ControllableYoutubePlayer/ControlPanel.tsx
+++ b/src/modules/ControllableYoutubePlayer/ControlPanel.tsx
@@ -10,6 +10,7 @@ import {
   MdFullscreenExit,
 } from 'react-icons/md';
 import SeekBar from './SeekBar';
+import { useOverlay } from './useOverlay';
 
 interface ControlPanelProps {
   isPlaying: boolean;
@@ -30,6 +31,8 @@ const formatTime = (time: number) => {
   return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
 };
 
+
+
 const ControlPanel: React.FC<ControlPanelProps> = ({
   isPlaying,
   isTimeLimitReached,
@@ -42,36 +45,11 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
   isFullscreen,
   toggleFullscreen,
 }) => {
-  const [isHovered, setIsHovered] = useState(false);
   const [volume, setVolume] = useState(100);
   const [isMuted, setIsMuted] = useState(false);
-  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const showControls = !isPlaying || isHovered;
-
-  useEffect(() => {
-    if (isPlaying && !isHovered) {
-      hideTimeoutRef.current = setTimeout(() => setIsHovered(false), 3000);
-    }
-    return () => {
-      if (hideTimeoutRef.current) {
-        clearTimeout(hideTimeoutRef.current);
-      }
-    };
-  }, [isPlaying, isHovered]);
-
-  const handleMouseEnter = () => {
-    setIsHovered(true);
-    if (hideTimeoutRef.current) {
-      clearTimeout(hideTimeoutRef.current);
-    }
-  };
-
-  const handleMouseLeave = () => {
-    if (isPlaying) {
-      hideTimeoutRef.current = setTimeout(() => setIsHovered(false), 3000);
-    }
-  };
+  const { handleMouseEnter, handleMouseLeave, showControls } = useOverlay({
+    isPlaying,
+  });
 
   const toggleMute = useCallback(() => {
     if (playerRef.current) {
@@ -108,14 +86,6 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
       onMouseLeave={handleMouseLeave}
     >
       <div className="relative flex items-center space-x-2 text-white mb-4">
-        {/* <input
-          type="range"
-          min="0"
-          max={duration}
-          value={currentTime}
-          onChange={(e) => onSeek(Number(e.target.value))}
-          className="custom-range flex-grow"
-        /> */}
         <SeekBar
           currentTime={currentTime}
           duration={duration}

--- a/src/modules/ControllableYoutubePlayer/ControllableYoutubePlayer.tsx
+++ b/src/modules/ControllableYoutubePlayer/ControllableYoutubePlayer.tsx
@@ -5,11 +5,13 @@ import ControlPanel from './ControlPanel';
 interface YouTubePlayerProps {
   videoId: string;
   timeLimit: number; // in seconds
+  onPlayPause?: (isPlaying: boolean) => void; // New prop
 }
 
 const ControllableYoutubePlayer: React.FC<YouTubePlayerProps> = ({
   videoId,
   timeLimit,
+  onPlayPause,
 }) => {
   const [timeRemaining, setTimeRemaining] = useState(timeLimit);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -65,12 +67,14 @@ const ControllableYoutubePlayer: React.FC<YouTubePlayerProps> = ({
       if (!isTimeLimitReached) {
         setIsPlaying(true);
         startTimer();
+        if (onPlayPause) onPlayPause(true); // Call the callback
       } else {
         event.target.pauseVideo();
       }
     } else {
       setIsPlaying(false);
       stopTimer();
+      if (onPlayPause) onPlayPause(false); // Call the callback
     }
   };
 

--- a/src/modules/ControllableYoutubePlayer/ControllableYoutubePlayer.tsx
+++ b/src/modules/ControllableYoutubePlayer/ControllableYoutubePlayer.tsx
@@ -113,7 +113,7 @@ const ControllableYoutubePlayer: React.FC<YouTubePlayerProps> = ({
     if (playerRef.current?.pauseVideo) {
       playerRef.current.pauseVideo();
     }
-    // onTimeLimit();
+    onTimeLimit();
   }, [stopTimer]);
 
   const togglePlay = useCallback(() => {

--- a/src/modules/ControllableYoutubePlayer/ControllableYoutubePlayer.tsx
+++ b/src/modules/ControllableYoutubePlayer/ControllableYoutubePlayer.tsx
@@ -1,17 +1,22 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useFullscreen } from './useFullscreen';
 import ControlPanel from './ControlPanel';
+import WidgetPanel from './WidgetPanel';
 
 interface YouTubePlayerProps {
   videoId: string;
   timeLimit: number; // in seconds
-  onPlayPause?: (isPlaying: boolean) => void; // New prop
+  onPlayPause?: (isPlaying: boolean) => void;
+  onTimeLimit?: () => void;
+  renderWidget?: (state: object, actions: object) => React.ReactElement;
 }
 
 const ControllableYoutubePlayer: React.FC<YouTubePlayerProps> = ({
   videoId,
   timeLimit,
-  onPlayPause,
+  onPlayPause = () => null,
+  onTimeLimit = () => null,
+  renderWidget = (state, actions) => null,
 }) => {
   const [timeRemaining, setTimeRemaining] = useState(timeLimit);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -108,6 +113,7 @@ const ControllableYoutubePlayer: React.FC<YouTubePlayerProps> = ({
     if (playerRef.current?.pauseVideo) {
       playerRef.current.pauseVideo();
     }
+    // onTimeLimit();
   }, [stopTimer]);
 
   const togglePlay = useCallback(() => {
@@ -132,6 +138,10 @@ const ControllableYoutubePlayer: React.FC<YouTubePlayerProps> = ({
         className="absolute top-0 left-0 w-full h-full"
       ></div>
       <div className="absolute top-0 left-0 w-full h-full bg-black bg-opacity-50 flex flex-col justify-end">
+        <WidgetPanel
+          renderWidget={() => renderWidget({}, {})}
+          isPlaying={isPlaying}
+        />
         <ControlPanel
           isPlaying={isPlaying}
           isTimeLimitReached={isTimeLimitReached}

--- a/src/modules/ControllableYoutubePlayer/WidgetPanel.tsx
+++ b/src/modules/ControllableYoutubePlayer/WidgetPanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useOverlay } from './useOverlay';
+
+type Props = {
+  renderWidget: () => React.ReactElement;
+  isPlaying: boolean;
+};
+
+const WidgetPanel = ({ renderWidget, isPlaying }: Props) => {
+  const { handleMouseEnter, handleMouseLeave, showControls } = useOverlay({
+    isPlaying,
+  });
+
+  return (
+    <div
+      className={`absolute top-0 left-0 w-full h-[70%] bg-gray-700 bg-opacity-30 flex justify-center items-center ${
+        showControls ? 'opacity-100' : 'opacity-0'
+      }`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {renderWidget()}
+    </div>
+  );
+};
+
+export default WidgetPanel;

--- a/src/modules/ControllableYoutubePlayer/useOverlay.ts
+++ b/src/modules/ControllableYoutubePlayer/useOverlay.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useOverlay = ({ isPlaying }: { isPlaying: boolean }) => {
+  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    if (isPlaying && !isHovered) {
+      hideTimeoutRef.current = setTimeout(() => setIsHovered(false), 3000);
+    }
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+      }
+    };
+  }, [isPlaying, isHovered]);
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (isPlaying) {
+      hideTimeoutRef.current = setTimeout(() => setIsHovered(false), 3000);
+    }
+  };
+
+  const showControls = !isPlaying || isHovered;
+
+  return {
+    isHovered,
+    showControls,
+    handleMouseEnter,
+    handleMouseLeave,
+  };
+};

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,0 +1,10 @@
+export type IntervalStatus = 'passed' | 'current' | 'upcoming';
+
+export type Interval = {
+  startTime: Date;
+  endTime: Date;
+  icon: React.ReactElement | string;
+  color: string;
+  label: string;
+  status?: IntervalStatus;
+};


### PR DESCRIPTION
Integrate `ControllableYoutubePlayer` and `AnalogClock` into a new `CentralModule` to manage watch and break intervals, and store state in `localStorage`.

* **CentralModule**:
  - Create `CentralModule` to integrate `ControllableYoutubePlayer` and `AnalogClock`.
  - Implement logic to manage watch and break intervals.
  - Store state in `localStorage` to maintain the current state after page reloads.
  - Add play/pause functionality and interval updates.

* **src/app/page.tsx**:
  - Replace `ControllableYoutubePlayer` with `CentralModule`.

* **src/app/clock/page.tsx**:
  - Update to use intervals from `CentralModule` stored in `localStorage`.

